### PR TITLE
Fix inconsistent get records

### DIFF
--- a/src/org/nyu/edu/dlts/dbCopyFrame.java
+++ b/src/org/nyu/edu/dlts/dbCopyFrame.java
@@ -554,7 +554,7 @@ public class dbCopyFrame extends JFrame {
         CellConstraints cc = new CellConstraints();
 
         //======== this ========
-        setTitle("Archon Data Migrator v1.0.1 (09-08-2016)");
+        setTitle("Archon Data Migrator v1.0.2 (03-22-2017)");
         Container contentPane = getContentPane();
         contentPane.setLayout(new BorderLayout());
 

--- a/src/org/nyu/edu/dlts/utils/ArchonClient.java
+++ b/src/org/nyu/edu/dlts/utils/ArchonClient.java
@@ -776,7 +776,8 @@ public class ArchonClient {
         while (keys.hasNext()) {
             String key = keys.next();
             JSONObject jsoToAdd = jso.getJSONObject(key);
-            jsonObject.put(key, jsoToAdd);
+            String id = jsoToAdd.getString("ID");
+            jsonObject.put(id, jsoToAdd);
         }
     }
 


### PR DESCRIPTION
The appendToJSONObject and convertJSONArrayToJSONObject were
using different methods for adding json objects.

Append was using the row index from Archon, while convert used the
DB ID. These could overlap meaning some objects were replaced, not
added. By always using the DB ID we elimate this potential conflict.

This may fix some other problems were record lookup was used based
on a key (via append) from a row index which may not be the same as
as the DB ID (needed for correct associations).